### PR TITLE
feat: Execute tests in nested classes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,6 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           JCENTER_USER: ${{ secrets.JCENTER_USER }}
           JCENTER_PASSWORD: ${{ secrets.JCENTER_PASSWORD }}
-        run: ./gradlew clean publishAllPublicationsToMavenRepository bintrayUpload --no-daemon -Dorg.gradle.internal.publish.checksums.insecure=true
+        run: ./gradlew clean publishAllPublicationsToMavenRepository  --no-daemon -Dorg.gradle.internal.publish.checksums.insecure=true
 
 

--- a/gradle-example/build.gradle
+++ b/gradle-example/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation "org.scalatest:scalatest_2.12:3.2.0-M3"
     testRuntimeOnly "org.junit.platform:junit-platform-engine:1.6.0"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.6.0"
-    testRuntimeOnly "co.helmethair:scalatest-junit-runner:0.1.6"
+    testRuntimeOnly "co.helmethair:scalatest-junit-runner:0.1.5"
 }
 
 test {

--- a/src/main/java/co/helmethair/scalatest/ScalatestEngine.java
+++ b/src/main/java/co/helmethair/scalatest/ScalatestEngine.java
@@ -48,7 +48,7 @@ public class ScalatestEngine implements TestEngine {
     @SuppressWarnings("unchecked")
     private List<Class<? extends Suite>> discoverClassSelectors(EngineDiscoveryRequest dicoveryRequest) {
         return dicoveryRequest.getSelectorsByType(ClassSelector.class).stream().map(ClassSelector::getJavaClass)
-                .filter(c -> !( c.getEnclosingMethod()!=null //only local or anonymous classes have an enclosing method
+                .filter(c -> !(c.getEnclosingMethod() != null //only local or anonymous classes have an enclosing method
                         || c.isSynthetic()
                         || Modifier.isAbstract(c.getModifiers()))
                         && Suite.class.isAssignableFrom(c)

--- a/src/main/java/co/helmethair/scalatest/ScalatestEngine.java
+++ b/src/main/java/co/helmethair/scalatest/ScalatestEngine.java
@@ -48,20 +48,10 @@ public class ScalatestEngine implements TestEngine {
     @SuppressWarnings("unchecked")
     private List<Class<? extends Suite>> discoverClassSelectors(EngineDiscoveryRequest dicoveryRequest) {
         return dicoveryRequest.getSelectorsByType(ClassSelector.class).stream().map(ClassSelector::getJavaClass)
-                .filter(c -> !(willThowMalformedException(c)
-                        || c.isAnonymousClass()
-                        || c.isLocalClass()
+                .filter(c -> !( c.getEnclosingMethod()!=null //only local or anonymous classes have an enclosing method
                         || c.isSynthetic()
                         || Modifier.isAbstract(c.getModifiers()))
                         && Suite.class.isAssignableFrom(c)
                 ).map(c -> ((Class<? extends Suite>) c)).collect(Collectors.toList());
-    }
-
-    private boolean willThowMalformedException(Class<?> c) {
-        Class<?> enclosingClass = c.getEnclosingClass();
-        if (enclosingClass == null) return false;
-        String binaryName = c.getName().substring(enclosingClass.getName().length());
-        int length = binaryName.length();
-        return length < 1 || binaryName.charAt(0) != '$';
     }
 }

--- a/src/test/java/co/helmethair/scalatest/NestedClassTest.java
+++ b/src/test/java/co/helmethair/scalatest/NestedClassTest.java
@@ -20,6 +20,4 @@ class NestedClassTest implements TestHelpers {
 
         verifyTestExecuteCode(1, () -> engine.execute(executionRequest));
     }
-
-
 }

--- a/src/test/java/co/helmethair/scalatest/NestedClassTest.java
+++ b/src/test/java/co/helmethair/scalatest/NestedClassTest.java
@@ -12,12 +12,14 @@ import static org.mockito.Mockito.spy;
 class NestedClassTest implements TestHelpers {
 
     @Test
-    void useNested() { // No test will be executed but this should not fail with a "Malformed class name" exception
-        EngineDiscoveryRequest discoveryRequest = createClassDiscoveryRequest("tests.TestOuter$Inner$CaseClass");
+    void handleNested() {
+        EngineDiscoveryRequest discoveryRequest = createClassDiscoveryRequest("tests.TestOuter$Inner$CaseClass", "tests.TestOuter$Inner$NotCase");
         TestDescriptor discoveredTests = engine.discover(discoveryRequest, engineId);
         TestEngineExecutionListener listener = spy(new TestEngineExecutionListener());
         ExecutionRequest executionRequest = new ExecutionRequest(discoveredTests, listener, null);
 
-        verifyTestExecuteCode(0, () -> engine.execute(executionRequest));
+        verifyTestExecuteCode(1, () -> engine.execute(executionRequest));
     }
+
+
 }

--- a/src/test/scala/tests/TestOuter.scala
+++ b/src/test/scala/tests/TestOuter.scala
@@ -9,9 +9,9 @@ object TestOuter {
 
     case class CaseClass(a: String)
 
-    class NotCase() extends AnyFunSpec with RegisterCall{
+    class NotCase() extends AnyFunSpec with RegisterCall {
 
-    describe("NotCase") {
+      describe("NotCase") {
         it("runs") {
           register()
         }
@@ -19,4 +19,5 @@ object TestOuter {
     }
 
   }
+
 }

--- a/src/test/scala/tests/TestOuter.scala
+++ b/src/test/scala/tests/TestOuter.scala
@@ -1,11 +1,22 @@
 package tests
 
+import co.helmethair.scalatest.helper.RegisterCall
+import org.scalatest.funspec.AnyFunSpec
+
 object TestOuter {
 
   object Inner {
 
     case class CaseClass(a: String)
 
-  }
+    class NotCase() extends AnyFunSpec with RegisterCall{
 
+    describe("NotCase") {
+        it("runs") {
+          register()
+        }
+      }
+    }
+
+  }
 }


### PR DESCRIPTION
Java's isAbstract function was throwing an exception because certain nested Scala classes have "invalid" names. 0.1.6 filtered out those classes. This change re-enables the processing of such classes therefore running tests inside them/next to them without error.