### PR TITLE
Add support for UniqueId selectors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,8 +56,10 @@ dependencies {
     compileOnly("org.scalatest:scalatest_2.11:3.3.0-SNAP3")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
-    testImplementation("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
+    testImplementation("org.junit.platform:junit-platform-launcher:$junitPlatformVersion")
+    testImplementation("org.junit.platform:junit-platform-testkit:$junitPlatformVersion")
     testImplementation("org.junit.platform:junit-platform-engine:1.6.0")
     testImplementation("org.scalatest:scalatest_$testScalaLibraryVersion:3.3.0-SNAP3")
     testImplementation("org.scala-lang:scala-library:$testScalaVersion")

--- a/src/main/java/co/helmethair/scalatest/descriptor/ScalatestDescriptor.java
+++ b/src/main/java/co/helmethair/scalatest/descriptor/ScalatestDescriptor.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public abstract class ScalatestDescriptor implements TestDescriptor {
     final static UniqueId ENGINE_ID = UniqueId.forEngine(ScalatestEngine.ID);
     static final ConcurrentHashMap<UniqueId, ScalatestDescriptor> descriptorsById = new ConcurrentHashMap<>();
+    public static final String SUITE_TYPE = "suite";
     private final UniqueId id;
     private TestDescriptor parentDescriptor = null;
     private Set<TestDescriptor> childDescriptors = new HashSet<TestDescriptor>();
@@ -32,11 +33,11 @@ public abstract class ScalatestDescriptor implements TestDescriptor {
     }
 
     static UniqueId testId(String suiteId, String testName) {
-        return ENGINE_ID.append("suite", suiteId).append("test", testName);
+        return ENGINE_ID.append(SUITE_TYPE, suiteId).append("test", testName);
     }
 
     static UniqueId containerId(String suiteId) {
-        return ENGINE_ID.append("suite", suiteId);
+        return ENGINE_ID.append(SUITE_TYPE, suiteId);
     }
 
     static UniqueId descriptorId(String suiteId, String testName) {

--- a/src/test/java/co/helmethair/scalatest/UniqueIdTest.java
+++ b/src/test/java/co/helmethair/scalatest/UniqueIdTest.java
@@ -1,0 +1,26 @@
+package co.helmethair.scalatest;
+
+import co.helmethair.scalatest.helper.TestHelpers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+public class UniqueIdTest implements TestHelpers {
+
+    @ParameterizedTest
+    @CsvSource({"[engine:scalatest]/[suite:tests.NestedTest], 2, 0",
+        // For now, it does not support really executing the selected test, it will execute the whole suite
+        "[engine:scalatest]/[suite:tests.NestedTest]/[test:nested test1], 2, 0",
+        "[engine:scalatest]/[foo:tests.NestedTest], 0, 0",
+        "[engine:scalatest]/[suite:tests.UnknownFoo], 0, 1",
+    })
+    void handleUniqueId(String id, int successEvents, int failingEvents) {
+        EngineTestKit
+            .engine("scalatest")
+            .selectors(DiscoverySelectors.selectUniqueId(id))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.succeeded(successEvents).failed(failingEvents));
+    }
+}

--- a/src/test/java/co/helmethair/scalatest/helper/TestHelpers.java
+++ b/src/test/java/co/helmethair/scalatest/helper/TestHelpers.java
@@ -57,7 +57,7 @@ public interface TestHelpers {
                 if (selectorType == ClassSelector.class) {
                     return ((List<T>) Arrays.stream(classNames).map(DiscoverySelectors::selectClass).collect(Collectors.toList()));
                 }
-                return null;
+                return Collections.emptyList();
             }
 
             @Override


### PR DESCRIPTION
This should fix https://github.com/helmethair-co/scalatest-junit-runner/issues/88 by enabling discovery by UniqueIds.

For example, given a selector `[engine:scalatest]/[suite:tests.SomeTest]`, it should discover `SomeTest`.
But given `[engine:scalatest]/[suite:tests.SomeTest]/[some method]`, it will still discover `SomeTest` and execute all its tests method. 
Supporting selecting only the provided method would require some refactoring in the `Discovery` class.
