### PR TITLE
Add support for UniqueId selectors, post merge fixes

### DIFF
--- a/src/test/java/co/helmethair/scalatest/UniqueIdTest.java
+++ b/src/test/java/co/helmethair/scalatest/UniqueIdTest.java
@@ -9,7 +9,9 @@ import org.junit.platform.testkit.engine.EngineTestKit;
 public class UniqueIdTest implements TestHelpers {
 
     @ParameterizedTest
-    @CsvSource({"[engine:scalatest]/[suite:tests.NestedTest], 2, 0",
+    @CsvSource({
+        "[engine:scalatest], 0, 0",
+        "[engine:scalatest]/[suite:tests.NestedTest], 2, 0",
         // For now, it does not support really executing the selected test, it will execute the whole suite
         "[engine:scalatest]/[suite:tests.NestedTest]/[test:nested test1], 2, 0",
         "[engine:scalatest]/[foo:tests.NestedTest], 0, 0",


### PR DESCRIPTION
In context of https://github.com/helmethair-co/scalatest-junit-runner/pull/91, post merge review lead to:
- Small refactor to use Streams
- Potential bug fix in case of passing `[engine:scalatest]`