### PR TITLE
Support discovery of suites with failed initialization by `UniqueId`

### DIFF
--- a/src/main/java/co/helmethair/scalatest/ScalatestEngine.java
+++ b/src/main/java/co/helmethair/scalatest/ScalatestEngine.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static co.helmethair.scalatest.descriptor.ScalatestDescriptor.INIT_FAILURE_TYPE;
 import static co.helmethair.scalatest.descriptor.ScalatestDescriptor.SUITE_TYPE;
 
 public class ScalatestEngine implements TestEngine {
@@ -65,7 +66,7 @@ public class ScalatestEngine implements TestEngine {
         UniqueId uniqueId = u.getUniqueId();
         if (uniqueId.hasPrefix(UniqueId.forEngine(ID)) && uniqueId.getSegments().size() > 1) {
             UniqueId.Segment segment = uniqueId.getSegments().get(1);
-            if (SUITE_TYPE.equals(segment.getType())) {
+            if (SUITE_TYPE.equals(segment.getType()) || INIT_FAILURE_TYPE.equals(segment.getType())) {
                 return Optional.of(segment.getValue());
             }
         }

--- a/src/main/java/co/helmethair/scalatest/descriptor/ScalatestDescriptor.java
+++ b/src/main/java/co/helmethair/scalatest/descriptor/ScalatestDescriptor.java
@@ -14,6 +14,7 @@ public abstract class ScalatestDescriptor implements TestDescriptor {
     final static UniqueId ENGINE_ID = UniqueId.forEngine(ScalatestEngine.ID);
     static final ConcurrentHashMap<UniqueId, ScalatestDescriptor> descriptorsById = new ConcurrentHashMap<>();
     public static final String SUITE_TYPE = "suite";
+    public static final String INIT_FAILURE_TYPE = "failed";
     private final UniqueId id;
     private TestDescriptor parentDescriptor = null;
     private Set<TestDescriptor> childDescriptors = new HashSet<TestDescriptor>();

--- a/src/main/java/co/helmethair/scalatest/descriptor/ScalatestFailedInitDescriptor.java
+++ b/src/main/java/co/helmethair/scalatest/descriptor/ScalatestFailedInitDescriptor.java
@@ -12,7 +12,7 @@ public class ScalatestFailedInitDescriptor extends ScalatestDescriptor {
     private final String suiteId;
 
     public ScalatestFailedInitDescriptor(Throwable cause, String name, Set<TestTag> tags) {
-        super(ENGINE_ID.append("failed", name));
+        super(ENGINE_ID.append(INIT_FAILURE_TYPE, name));
         this.cause = cause;
         this.suiteId = name;
         this.tags = tags;

--- a/src/test/java/co/helmethair/scalatest/ClassInitializationErrorTest.java
+++ b/src/test/java/co/helmethair/scalatest/ClassInitializationErrorTest.java
@@ -8,8 +8,11 @@ import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.launcher.TestExecutionListener;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.spy;
 
 public class ClassInitializationErrorTest implements TestHelpers {
@@ -38,5 +41,23 @@ public class ClassInitializationErrorTest implements TestHelpers {
         String testId = "[engine:scalatest]/[failed:tests.InitErrorTaggedTest]";
         verifyTestStartReported(testId, listener);
         verifyTestFailReported(testId, listener);
+    }
+
+    @Test
+    void discoversFailedToInitializeClassByUniqueIdDescriptor() {
+        EngineDiscoveryRequest initialDiscoveryRequest = createClassDiscoveryRequest("tests.InitErrorTest");
+        TestDescriptor initialDiscoveryResult = engine.discover(initialDiscoveryRequest, engineId);
+        TestDescriptor initErrorDescriptor = uniqueChild(initialDiscoveryResult);
+        assertEquals("[engine:scalatest]/[failed:tests.InitErrorTest]", initErrorDescriptor.getUniqueId().toString());
+
+        EngineDiscoveryRequest idBasedDiscoveryRequest = createUniqueIdDiscoveryRequest(initErrorDescriptor.getUniqueId().toString());
+        TestDescriptor idBasedDiscoveryResult = engine.discover(idBasedDiscoveryRequest, engineId);
+        assertEquals("[engine:scalatest]/[failed:tests.InitErrorTest]", uniqueChild(idBasedDiscoveryResult).getUniqueId().toString());
+    }
+
+    private static TestDescriptor uniqueChild(TestDescriptor parent) {
+        Set<? extends TestDescriptor> children = parent.getChildren();
+        assertEquals(1, children.size());
+        return new ArrayList<>(children).get(0);
     }
 }

--- a/src/test/java/co/helmethair/scalatest/helper/TestHelpers.java
+++ b/src/test/java/co/helmethair/scalatest/helper/TestHelpers.java
@@ -4,6 +4,7 @@ import co.helmethair.scalatest.ScalatestEngine;
 import org.junit.platform.engine.*;
 import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.launcher.*;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
@@ -21,12 +22,16 @@ public interface TestHelpers {
 
     ScalatestEngine engine = new ScalatestEngine();
 
+    default EngineDiscoveryRequest createUniqueIdDiscoveryRequest(String... uniqueIds) {
+        return createUniqueIdDiscoveryRequest(null, uniqueIds);
+    }
+
     default EngineDiscoveryRequest createClassDiscoveryRequest(String... classNames) {
         return createClassDiscoveryRequest(null, classNames);
     }
 
     default ConfigurationParameters configurationParametersOf(Map<String, Object> configParams) {
-        return new ConfigurationParameters() {            
+        return new ConfigurationParameters() {
             @Override
             public Set<String> keySet() {
                 return configParams.keySet();
@@ -56,6 +61,29 @@ public interface TestHelpers {
             public <T extends DiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType) {
                 if (selectorType == ClassSelector.class) {
                     return ((List<T>) Arrays.stream(classNames).map(DiscoverySelectors::selectClass).collect(Collectors.toList()));
+                }
+                return Collections.emptyList();
+            }
+
+            @Override
+            public <T extends DiscoveryFilter<?>> List<T> getFiltersByType(Class<T> filterType) {
+                return null;
+            }
+
+            @Override
+            public ConfigurationParameters getConfigurationParameters() {
+                return configParams;
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    default EngineDiscoveryRequest createUniqueIdDiscoveryRequest(ConfigurationParameters configParams, String... uniqueIds) {
+        return new EngineDiscoveryRequest() {
+            @Override
+            public <T extends DiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType) {
+                if (selectorType == UniqueIdSelector.class) {
+                    return ((List<T>) Arrays.stream(uniqueIds).map(DiscoverySelectors::selectUniqueId).collect(Collectors.toList()));
                 }
                 return Collections.emptyList();
             }


### PR DESCRIPTION
See the linked issue for more context.

Resolves #109 